### PR TITLE
ci: GitHub Actions pipeline for lint, test, type-check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## What
+<!-- Brief description of the change -->
+
+## Why
+<!-- Motivation and context -->
+
+## How
+<!-- Implementation details -->
+
+## Testing
+- [ ] Unit tests pass
+- [ ] Manual testing done
+- [ ] No security regressions
+
+Closes #<!-- issue number -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,108 @@
+name: CI
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install ruff
+      - run: ruff check backend/ tests/
+
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -r requirements.txt
+      - run: mypy backend/ --ignore-missing-imports
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    services:
+      postgres-app:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: querymate
+          POSTGRES_PASSWORD: querymate_secret
+          POSTGRES_DB: querymate_app
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      postgres-target:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: demo_user
+          POSTGRES_PASSWORD: demo_secret
+          POSTGRES_DB: ecommerce_demo
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -r requirements.txt
+      - name: Seed target database
+        run: PGPASSWORD=demo_secret psql -h localhost -p 5433 -U demo_user -d ecommerce_demo -f scripts/01_schema.sql
+      - name: Run tests
+        env:
+          APP_DATABASE_URL: postgresql+asyncpg://querymate:querymate_secret@localhost:5432/querymate_app
+          TARGET_DATABASE_URL: postgresql://demo_user:demo_secret@localhost:5433/ecommerce_demo
+          REDIS_URL: redis://localhost:6379/0
+          OPENAI_API_KEY: sk-test-fake-key
+          OPENAI_MODEL: gpt-4o-mini
+          APP_ENV: test
+        run: pytest tests/ -v --tb=short
+
+  build-frontend:
+    name: Build Frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Check if frontend exists
+        id: check
+        run: test -f package.json && echo "exists=true" >> $GITHUB_OUTPUT || echo "exists=false" >> $GITHUB_OUTPUT
+      - name: Install dependencies
+        if: steps.check.outputs.exists == 'true'
+        run: npm ci
+      - name: Build
+        if: steps.check.outputs.exists == 'true'
+        run: npm run build


### PR DESCRIPTION
## What
CI pipeline that runs automatically on every PR to `develop` and `main`.

## Why
Continuous Integration prevents broken code from reaching the integration branch. Every PR must pass lint, type-check, and tests before it can be merged.

## How
- `.github/workflows/ci.yml` — 4 parallel jobs:
  - **Lint** — `ruff check` for code style and common errors
  - **Type Check** — `mypy` for static type analysis
  - **Test** — `pytest` with PostgreSQL (x2) and Redis service containers
  - **Build Frontend** — `npm ci && npm run build` (skips if no package.json yet)
- `.github/pull_request_template.md` — Standard PR template with What/Why/How/Testing

## Testing
- [ ] CI runs on this PR itself
- [ ] Lint and typecheck jobs pass (no backend code to fail yet)
- [ ] Test job runs (may have no tests to discover yet — that's expected)

Closes #4