### PR TITLE
feat(models): SQLAlchemy models and Alembic migrations

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,36 @@
+[alembic]
+script_location = alembic
+prepend_sys_path = .
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,47 @@
+import asyncio
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from backend.core.config import settings
+from backend.core.database import Base
+from backend.models.query_history import QueryHistory  # noqa: F401
+
+config = context.config
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode — generates SQL without connecting."""
+    context.configure(
+        url=settings.app_database_url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={'paramstyle': 'named'},
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection) -> None:
+    context.configure(connection=connection, target_metadata=target_metadata)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_migrations_online() -> None:
+    """Run migrations in 'online' mode — connects to the database."""
+    connectable = create_async_engine(settings.app_database_url)
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+    await connectable.dispose()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    asyncio.run(run_migrations_online())

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,25 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/alembic/versions/001_create_query_history.py
+++ b/alembic/versions/001_create_query_history.py
@@ -1,0 +1,45 @@
+"""Create query_history table
+
+Revision ID: 001
+Revises:
+Create Date: 2026-03-21
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = '001'
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'query_history',
+        sa.Column('id', sa.Uuid(), primary_key=True),
+        sa.Column('natural_language', sa.Text(), nullable=False),
+        sa.Column('generated_sql', sa.Text(), nullable=False),
+        sa.Column('execution_time_ms', sa.Float(), nullable=True),
+        sa.Column('row_count', sa.Integer(), nullable=True),
+        sa.Column('was_cached', sa.Boolean(), server_default='false'),
+        sa.Column('cache_level', sa.String(2), nullable=True),
+        sa.Column('error', sa.Text(), nullable=True),
+        sa.Column(
+            'created_at',
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        'idx_query_history_created_at',
+        'query_history',
+        ['created_at'],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('idx_query_history_created_at')
+    op.drop_table('query_history')

--- a/backend/core/database.py
+++ b/backend/core/database.py
@@ -1,0 +1,30 @@
+from collections.abc import AsyncGenerator
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import DeclarativeBase
+
+from backend.core.config import settings
+
+engine = create_async_engine(
+    settings.app_database_url,
+    echo=settings.app_env == 'development',
+    pool_size=5,
+    max_overflow=10,
+)
+
+async_session = async_sessionmaker(engine, expire_on_commit=False)
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    """FastAPI dependency that yields an async database session."""
+    async with async_session() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise

--- a/backend/models/query_history.py
+++ b/backend/models/query_history.py
@@ -1,0 +1,26 @@
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.core.database import Base
+
+
+class QueryHistory(Base):
+    """Tracks every NL query, the generated SQL, timing, and cache info."""
+
+    __tablename__ = 'query_history'
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True, default=uuid.uuid4
+    )
+    natural_language: Mapped[str]
+    generated_sql: Mapped[str]
+    execution_time_ms: Mapped[Optional[float]] = mapped_column(default=None)
+    row_count: Mapped[Optional[int]] = mapped_column(default=None)
+    was_cached: Mapped[bool] = mapped_column(default=False)
+    cache_level: Mapped[Optional[str]] = mapped_column(default=None)
+    error: Mapped[Optional[str]] = mapped_column(default=None)
+    created_at: Mapped[datetime] = mapped_column(server_default=func.now())


### PR DESCRIPTION
## What
Application database layer with async SQLAlchemy 2.0 and Alembic migrations.

## Why
Query history tracking enables analytics (cache hit rates, popular queries, error patterns) and the history API endpoint. Alembic migrations ensure the schema is versioned and reproducible — `alembic upgrade head` on any machine creates the correct schema.

## How
- `backend/core/database.py` — Async engine + session factory with auto commit/rollback
- `backend/models/query_history.py` — `QueryHistory` model (id, nl_query, sql, timing, cache_level, error)
- `alembic/` — Async Alembic env.py, script template, initial migration

## Testing
- [ ] `alembic upgrade head` creates `query_history` table
- [ ] `alembic downgrade -1` drops it cleanly
- [ ] Model uses SQLAlchemy 2.0 `mapped_column` syntax (not legacy `Column`)

Closes #6