### PR TITLE
feat(db): target database connection with read-only user

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from backend.api.health import router as health_router
 from backend.core.config import settings
 from backend.core.logging import setup_logging
+from backend.core.target_database import close_target_pool, init_target_pool
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +17,9 @@ async def lifespan(app: FastAPI):
     """Startup and shutdown events."""
     setup_logging()
     logger.info('QueryMate AI starting — env=%s', settings.app_env)
+    init_target_pool()
     yield
+    close_target_pool()
     logger.info('QueryMate AI shutting down')
 
 

--- a/backend/core/target_database.py
+++ b/backend/core/target_database.py
@@ -1,0 +1,77 @@
+import logging
+from contextlib import contextmanager
+from urllib.parse import urlparse
+
+import psycopg2
+from psycopg2 import pool
+
+from backend.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+_pool: pool.ThreadedConnectionPool | None = None
+
+
+def _parse_dsn() -> dict:
+    """Parse the target database URL into psycopg2 connection params."""
+    parsed = urlparse(settings.target_database_url)
+    return {
+        'host': parsed.hostname or 'localhost',
+        'port': parsed.port or 5432,
+        'dbname': parsed.path.lstrip('/'),
+        'user': parsed.username or 'demo_user',
+        'password': parsed.password or 'demo_secret',
+    }
+
+
+def init_target_pool() -> None:
+    """Create the connection pool for the target database."""
+    global _pool
+    if _pool is not None:
+        return
+
+    params = _parse_dsn()
+    _pool = pool.ThreadedConnectionPool(
+        minconn=2,
+        maxconn=10,
+        **params,
+    )
+    logger.info(
+        'Target DB pool created — host=%s dbname=%s user=%s',
+        params['host'],
+        params['dbname'],
+        params['user'],
+    )
+
+
+def close_target_pool() -> None:
+    """Close all connections in the pool."""
+    global _pool
+    if _pool is not None:
+        _pool.closeall()
+        _pool = None
+        logger.info('Target DB pool closed')
+
+
+@contextmanager
+def get_target_connection():
+    """Yield a read-only connection with statement timeout.
+
+    Safety layers applied at connection level:
+    - statement_timeout: cancels queries exceeding the limit
+    - default_transaction_read_only: enforces read-only at connection level
+    """
+    if _pool is None:
+        init_target_pool()
+
+    conn = _pool.getconn()
+    try:
+        conn.set_session(readonly=True, autocommit=True)
+        with conn.cursor() as cur:
+            cur.execute(
+                'SET statement_timeout = %s',
+                (f'{settings.query_timeout_seconds}s',),
+            )
+        yield conn
+    finally:
+        _pool.putconn(conn)


### PR DESCRIPTION
## What
Synchronous psycopg2 connection pool for the target database (the one users query with natural language).

## Why
The target DB connection is intentionally separate from the app DB:
- **App DB** uses async SQLAlchemy (ORM for structured models)
- **Target DB** uses sync psycopg2 (executes raw LLM-generated SQL)

Two defense-in-depth layers are applied at connection level:
- `readonly=True` — enforces read-only at psycopg2 level (Layer 2)
- `statement_timeout` — cancels slow queries (Layer 4)

## How
- `backend/core/target_database.py` — ThreadedConnectionPool (2-10 connections), read-only session, statement timeout, context manager
- `backend/app/main.py` — Pool initialized on startup, closed on shutdown via lifespan

## Testing
- [ ] Pool initializes without error when target DB is running
- [ ] `readonly=True` prevents any write operations
- [ ] Slow queries are cancelled after `query_timeout_seconds`

Closes #7