### PR TITLE
fix(ci): resolve lint errors and empty test suite failure

### DIFF
--- a/backend/core/target_database.py
+++ b/backend/core/target_database.py
@@ -2,7 +2,6 @@ import logging
 from contextlib import contextmanager
 from urllib.parse import urlparse
 
-import psycopg2
 from psycopg2 import pool
 
 from backend.core.config import settings

--- a/backend/services/query_executor.py
+++ b/backend/services/query_executor.py
@@ -4,7 +4,7 @@ with timeout enforcement, row limits, and structured error handling.
 
 import logging
 import time
-from typing import Any, Optional
+from typing import Any
 
 import psycopg2
 from pydantic import BaseModel

--- a/backend/services/sql_validator.py
+++ b/backend/services/sql_validator.py
@@ -14,7 +14,6 @@ Design decision: regex over SQL parser (sqlparse)
 """
 
 import re
-from typing import Optional
 
 from pydantic import BaseModel
 

--- a/tests/unit/test_placeholder.py
+++ b/tests/unit/test_placeholder.py
@@ -1,0 +1,8 @@
+"""Placeholder test to prevent pytest exit code 5 (no tests collected).
+This file will be removed when real tests are added in Phase 7.
+"""
+
+
+def test_placeholder():
+    """Verify test infrastructure works."""
+    assert True


### PR DESCRIPTION
## What
Fix CI failures on lint and test jobs.

## Why
All CI runs since Phase 2c have been failing due to:
1. **Lint (ruff)**: 3 unused imports — `psycopg2` in target_database.py, `Optional` in query_executor.py and sql_validator.py
2. **Test (pytest)**: Exit code 5 — "no tests collected" causes pytest to fail

## How
- Removed 3 unused imports flagged by ruff
- Added `tests/unit/test_placeholder.py` with a single `assert True` test to prevent exit code 5 (will be replaced by real tests in Phase 7)

## Testing
- [ ] `ruff check backend/ tests/` passes with 0 errors
- [ ] `pytest tests/ -v` collects and passes 1 test