### PR TITLE
feat(api): REST endpoints for query, history, schema, cache

### DIFF
--- a/backend/api/cache.py
+++ b/backend/api/cache.py
@@ -1,0 +1,26 @@
+"""Cache management endpoints — stats and invalidation."""
+
+import logging
+
+from fastapi import APIRouter
+
+from backend.api.schemas import CacheStatsResponse
+from backend.services import cache_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix='/api/cache', tags=['cache'])
+
+
+@router.get('/stats', response_model=CacheStatsResponse)
+async def cache_stats() -> CacheStatsResponse:
+    """Get cache hit/miss statistics for both levels."""
+    stats = await cache_service.get_cache_stats()
+    return CacheStatsResponse(**stats.model_dump())
+
+
+@router.post('/invalidate')
+async def invalidate_cache() -> dict:
+    """Clear all query caches (preserves stats)."""
+    await cache_service.invalidate_all()
+    return {'message': 'All caches invalidated'}

--- a/backend/api/history.py
+++ b/backend/api/history.py
@@ -1,0 +1,73 @@
+"""Query history endpoints — view and manage past queries."""
+
+import logging
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.api.schemas import HistoryItem, HistoryResponse
+from backend.core.database import get_db
+from backend.models.query_history import QueryHistory
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix='/api/history', tags=['history'])
+
+
+@router.get('', response_model=HistoryResponse)
+async def list_history(
+    page: int = 1,
+    page_size: int = 20,
+    search: str | None = None,
+    db: AsyncSession = Depends(get_db),
+) -> HistoryResponse:
+    """List query history with pagination and optional search."""
+    query = select(QueryHistory).order_by(QueryHistory.created_at.desc())
+    count_query = select(func.count()).select_from(QueryHistory)
+
+    if search:
+        query = query.where(
+            QueryHistory.natural_language.ilike(f'%{search}%')
+        )
+        count_query = count_query.where(
+            QueryHistory.natural_language.ilike(f'%{search}%')
+        )
+
+    total = (await db.execute(count_query)).scalar() or 0
+
+    offset = (page - 1) * page_size
+    query = query.offset(offset).limit(page_size)
+    result = await db.execute(query)
+    rows = result.scalars().all()
+
+    return HistoryResponse(
+        items=[
+            HistoryItem(
+                id=row.id,
+                natural_language=row.natural_language,
+                generated_sql=row.generated_sql,
+                execution_time_ms=row.execution_time_ms,
+                row_count=row.row_count,
+                was_cached=row.was_cached,
+                cache_level=row.cache_level,
+                error=row.error,
+                created_at=row.created_at,
+            )
+            for row in rows
+        ],
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@router.delete('')
+async def clear_history(db: AsyncSession = Depends(get_db)) -> dict:
+    """Clear all query history."""
+    from sqlalchemy import delete
+
+    await db.execute(delete(QueryHistory))
+    await db.commit()
+    logger.info('Query history cleared')
+    return {'message': 'History cleared'}

--- a/backend/api/query.py
+++ b/backend/api/query.py
@@ -1,0 +1,176 @@
+"""Query endpoint — the main orchestrator that ties all services together.
+
+Flow:
+  1. Normalize question → check L1 cache
+  2. If L1 miss: introspect schema → call LLM → validate SQL → cache in L1
+  3. Check L2 cache with the SQL
+  4. If L2 miss: execute query → cache results in L2
+  5. Save to history (async, non-blocking)
+  6. Return response
+"""
+
+import logging
+import time
+import uuid
+
+from fastapi import APIRouter, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.api.schemas import QueryRequest, QueryResponse
+from backend.core.database import async_session
+from backend.models.query_history import QueryHistory
+from backend.services import cache_service
+from backend.services.introspector import introspect_schema
+from backend.services.llm_service import generate_sql
+from backend.services.query_executor import QueryError, QueryResult, execute_query
+from backend.services.sql_validator import validate_sql
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix='/api', tags=['query'])
+
+
+async def _save_history(
+    query_id: uuid.UUID,
+    question: str,
+    sql: str,
+    execution_time_ms: float,
+    row_count: int | None,
+    was_cached: bool,
+    cache_level: str | None,
+    error: str | None,
+) -> None:
+    """Save query to history (best-effort, non-blocking)."""
+    try:
+        async with async_session() as session:
+            record = QueryHistory(
+                id=query_id,
+                natural_language=question,
+                generated_sql=sql,
+                execution_time_ms=execution_time_ms,
+                row_count=row_count,
+                was_cached=was_cached,
+                cache_level=cache_level,
+                error=error,
+            )
+            session.add(record)
+            await session.commit()
+    except Exception as e:
+        logger.warning('Failed to save query history: %s', e)
+
+
+@router.post('/query', response_model=QueryResponse)
+async def query(request: QueryRequest) -> QueryResponse:
+    """Execute a natural language query against the target database."""
+    start = time.perf_counter()
+    query_id = uuid.uuid4()
+    question = request.question
+    sql = ''
+    cache_level = None
+    was_cached = False
+
+    try:
+        # Step 1: Check L1 cache (NL → SQL)
+        cached_sql = await cache_service.get_cached_sql(question)
+        if cached_sql is not None:
+            sql = cached_sql
+            cache_level = 'L1'
+        else:
+            # Step 2: Introspect schema → generate SQL
+            schema = introspect_schema()
+            sql = await generate_sql(question, schema)
+
+            # Step 3: Validate SQL
+            validation = validate_sql(sql)
+            if not validation.is_valid:
+                elapsed = (time.perf_counter() - start) * 1000
+                await _save_history(
+                    query_id, question, sql, elapsed, None, False, None,
+                    '; '.join(validation.violations),
+                )
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        'message': 'Query blocked by security validator',
+                        'violations': validation.violations,
+                        'sql': sql,
+                    },
+                )
+
+            # Cache NL → SQL in L1
+            await cache_service.set_cached_sql(question, sql)
+
+        # Step 4: Check L2 cache (SQL → Results)
+        cached_result = await cache_service.get_cached_result(sql)
+        if cached_result is not None:
+            was_cached = True
+            if cache_level == 'L1':
+                cache_level = 'L1+L2'
+            else:
+                cache_level = 'L2'
+
+            elapsed = (time.perf_counter() - start) * 1000
+            await _save_history(
+                query_id, question, sql, elapsed,
+                cached_result.row_count, True, cache_level, None,
+            )
+            return QueryResponse(
+                query_id=query_id,
+                question=question,
+                sql=sql,
+                result=cached_result.model_dump(),
+                execution_time_ms=round(elapsed, 2),
+                cached=True,
+                cache_level=cache_level,
+            )
+
+        # Step 5: Execute query
+        result = execute_query(sql)
+
+        if isinstance(result, QueryError):
+            elapsed = (time.perf_counter() - start) * 1000
+            await _save_history(
+                query_id, question, sql, elapsed, None, False, None,
+                result.message,
+            )
+            status_map = {
+                'timeout': 408,
+                'permission_denied': 403,
+                'syntax_error': 400,
+                'unknown_table': 400,
+                'unknown_column': 400,
+                'database_error': 500,
+            }
+            raise HTTPException(
+                status_code=status_map.get(result.error_type, 500),
+                detail={'message': result.message, 'error_type': result.error_type},
+            )
+
+        # Step 6: Cache results in L2
+        await cache_service.set_cached_result(sql, result)
+
+        elapsed = (time.perf_counter() - start) * 1000
+        await _save_history(
+            query_id, question, sql, elapsed,
+            result.row_count, was_cached, cache_level, None,
+        )
+
+        return QueryResponse(
+            query_id=query_id,
+            question=question,
+            sql=sql,
+            result=result.model_dump(),
+            execution_time_ms=round(elapsed, 2),
+            cached=was_cached,
+            cache_level=cache_level,
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        elapsed = (time.perf_counter() - start) * 1000
+        logger.error('Query failed: %s', e, exc_info=True)
+        await _save_history(
+            query_id, question, sql, elapsed, None, False, None, str(e),
+        )
+        raise HTTPException(status_code=500, detail={'message': str(e)})

--- a/backend/api/schema.py
+++ b/backend/api/schema.py
@@ -1,0 +1,63 @@
+"""Schema exploration endpoints — browse the target database structure."""
+
+import logging
+
+from fastapi import APIRouter, HTTPException
+
+from backend.api.schemas import ColumnSchema, SchemaResponse, TableSchema
+from backend.services.introspector import introspect_schema
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix='/api/schema', tags=['schema'])
+
+
+@router.get('', response_model=SchemaResponse)
+async def get_schema() -> SchemaResponse:
+    """Get the full target database schema."""
+    schema = introspect_schema()
+    return SchemaResponse(
+        tables=[
+            TableSchema(
+                name=t.name,
+                columns=[
+                    ColumnSchema(
+                        name=c.name,
+                        data_type=c.data_type,
+                        is_nullable=c.is_nullable,
+                        is_primary_key=c.is_primary_key,
+                        foreign_key=c.foreign_key,
+                        sample_values=c.sample_values,
+                    )
+                    for c in t.columns
+                ],
+                row_count=t.row_count,
+            )
+            for t in schema.tables
+        ],
+        table_count=len(schema.tables),
+    )
+
+
+@router.get('/{table_name}', response_model=TableSchema)
+async def get_table(table_name: str) -> TableSchema:
+    """Get schema details for a single table."""
+    schema = introspect_schema()
+    for t in schema.tables:
+        if t.name == table_name:
+            return TableSchema(
+                name=t.name,
+                columns=[
+                    ColumnSchema(
+                        name=c.name,
+                        data_type=c.data_type,
+                        is_nullable=c.is_nullable,
+                        is_primary_key=c.is_primary_key,
+                        foreign_key=c.foreign_key,
+                        sample_values=c.sample_values,
+                    )
+                    for c in t.columns
+                ],
+                row_count=t.row_count,
+            )
+    raise HTTPException(status_code=404, detail=f'Table "{table_name}" not found')

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -1,0 +1,83 @@
+"""Pydantic request/response models for the API."""
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+# ── Query ──
+
+class QueryRequest(BaseModel):
+    question: str = Field(
+        ...,
+        min_length=3,
+        max_length=500,
+        examples=['How many customers are in California?'],
+    )
+
+
+class QueryResponse(BaseModel):
+    query_id: UUID
+    question: str
+    sql: str
+    result: dict[str, Any] | None = None
+    error: str | None = None
+    execution_time_ms: float
+    cached: bool = False
+    cache_level: str | None = None
+
+
+# ── History ──
+
+class HistoryItem(BaseModel):
+    id: UUID
+    natural_language: str
+    generated_sql: str
+    execution_time_ms: float | None
+    row_count: int | None
+    was_cached: bool
+    cache_level: str | None
+    error: str | None
+    created_at: datetime
+
+
+class HistoryResponse(BaseModel):
+    items: list[HistoryItem]
+    total: int
+    page: int
+    page_size: int
+
+
+# ── Schema ──
+
+class ColumnSchema(BaseModel):
+    name: str
+    data_type: str
+    is_nullable: bool
+    is_primary_key: bool
+    foreign_key: str | None = None
+    sample_values: list[str] | None = None
+
+
+class TableSchema(BaseModel):
+    name: str
+    columns: list[ColumnSchema]
+    row_count: int | None = None
+
+
+class SchemaResponse(BaseModel):
+    tables: list[TableSchema]
+    table_count: int
+
+
+# ── Cache ──
+
+class CacheStatsResponse(BaseModel):
+    l1_hits: int
+    l1_misses: int
+    l2_hits: int
+    l2_misses: int
+    l1_hit_rate: float
+    l2_hit_rate: float

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,11 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from backend.api.cache import router as cache_router
 from backend.api.health import router as health_router
+from backend.api.history import router as history_router
+from backend.api.query import router as query_router
+from backend.api.schema import router as schema_router
 from backend.core.config import settings
 from backend.core.logging import setup_logging
 from backend.core.redis import close_redis, init_redis
@@ -44,3 +48,7 @@ app.add_middleware(
 )
 
 app.include_router(health_router)
+app.include_router(query_router)
+app.include_router(history_router)
+app.include_router(schema_router)
+app.include_router(cache_router)


### PR DESCRIPTION
## What
Complete REST API layer that orchestrates all backend services.

## Why
This is where the 4 core services (introspector, LLM, validator, executor) and the cache come together. The `/api/query` endpoint is the conductor — it calls each service in order with proper error handling at each step.

## How

### Endpoints
| Method | Endpoint | Purpose |
|--------|----------|---------|
| POST | `/api/query` | Main orchestrator — NL → SQL → validate → execute |
| GET | `/api/history` | Paginated query history with search |
| DELETE | `/api/history` | Clear all history |
| GET | `/api/schema` | Full database schema |
| GET | `/api/schema/{table}` | Single table detail |
| GET | `/api/cache/stats` | L1/L2 hit/miss ratios |
| POST | `/api/cache/invalidate` | Clear all caches |

### Query Flow
1. Normalize question → check L1 cache
2. L1 miss → introspect schema → call LLM → validate SQL → cache in L1
3. Check L2 cache → L2 miss → execute query → cache in L2
4. Save to history (best-effort) → return response

### Error Mapping
- Validator violations → 400
- Query timeout → 408
- Permission denied → 403
- Syntax/table/column errors → 400
- Database errors → 500

## Testing
- [ ] `POST /api/query` returns SQL + results for valid questions
- [ ] Invalid SQL returns 400 with violation details
- [ ] `/docs` shows all endpoints with schemas

Closes #13