### PR TITLE
feat(frontend): React + TypeScript + Vite + Tailwind setup

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+dist-ssr
+*.local
+.vite

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>QueryMate AI</title>
+    <meta name="description" content="Natural language to SQL query engine" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "querymate-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "lint": "eslint .",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.7.7",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "recharts": "^2.12.7"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.3",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.47",
+    "tailwindcss": "^3.4.14",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.10"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,16 @@
+import { Layout } from './components/Layout';
+
+function App() {
+  return (
+    <Layout>
+      <div className="bg-white rounded-lg shadow-sm border border-slate-200 p-8">
+        <h2 className="text-2xl font-semibold text-slate-900">Welcome to QueryMate AI</h2>
+        <p className="mt-2 text-slate-600">
+          Frontend setup complete. Query interface coming in the next PR.
+        </p>
+      </div>
+    </Layout>
+  );
+}
+
+export default App;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,47 @@
+import axios from 'axios';
+import type {
+  QueryRequest,
+  QueryResponse,
+  HistoryResponse,
+  SchemaResponse,
+  CacheStats,
+} from '../types';
+
+const API_BASE = import.meta.env.VITE_API_URL || '/api';
+
+const client = axios.create({
+  baseURL: API_BASE,
+  timeout: 30_000,
+});
+
+export const api = {
+  async query(request: QueryRequest): Promise<QueryResponse> {
+    const { data } = await client.post<QueryResponse>('/query', request);
+    return data;
+  },
+
+  async getHistory(page = 1, pageSize = 20, search?: string): Promise<HistoryResponse> {
+    const { data } = await client.get<HistoryResponse>('/history', {
+      params: { page, page_size: pageSize, search },
+    });
+    return data;
+  },
+
+  async clearHistory(): Promise<void> {
+    await client.delete('/history');
+  },
+
+  async getSchema(): Promise<SchemaResponse> {
+    const { data } = await client.get<SchemaResponse>('/schema');
+    return data;
+  },
+
+  async getCacheStats(): Promise<CacheStats> {
+    const { data } = await client.get<CacheStats>('/cache/stats');
+    return data;
+  },
+
+  async invalidateCache(): Promise<void> {
+    await client.post('/cache/invalidate');
+  },
+};

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from 'react';
+
+interface LayoutProps {
+  children: ReactNode;
+}
+
+export function Layout({ children }: LayoutProps) {
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <header className="bg-white border-b border-slate-200 shadow-sm">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <div className="w-8 h-8 bg-brand-600 rounded-lg flex items-center justify-center">
+                <span className="text-white font-bold">Q</span>
+              </div>
+              <div>
+                <h1 className="text-xl font-bold text-slate-900">QueryMate AI</h1>
+                <p className="text-xs text-slate-500">Natural language to SQL</p>
+              </div>
+            </div>
+            <a
+              href="https://github.com/Nishchal45/querymate-ai"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-slate-600 hover:text-slate-900"
+            >
+              GitHub →
+            </a>
+          </div>
+        </div>
+      </header>
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">{children}</main>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,9 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  body {
+    @apply bg-slate-50 text-slate-900 antialiased;
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,70 @@
+export interface QueryRequest {
+  question: string;
+}
+
+export interface QueryResult {
+  columns: string[];
+  rows: (string | number | null)[][];
+  row_count: number;
+  execution_time_ms: number;
+  truncated: boolean;
+}
+
+export interface QueryResponse {
+  query_id: string;
+  question: string;
+  sql: string;
+  result: QueryResult | null;
+  error: string | null;
+  execution_time_ms: number;
+  cached: boolean;
+  cache_level: string | null;
+}
+
+export interface HistoryItem {
+  id: string;
+  natural_language: string;
+  generated_sql: string;
+  execution_time_ms: number | null;
+  row_count: number | null;
+  was_cached: boolean;
+  cache_level: string | null;
+  error: string | null;
+  created_at: string;
+}
+
+export interface HistoryResponse {
+  items: HistoryItem[];
+  total: number;
+  page: number;
+  page_size: number;
+}
+
+export interface ColumnSchema {
+  name: string;
+  data_type: string;
+  is_nullable: boolean;
+  is_primary_key: boolean;
+  foreign_key: string | null;
+  sample_values: string[] | null;
+}
+
+export interface TableSchema {
+  name: string;
+  columns: ColumnSchema[];
+  row_count: number | null;
+}
+
+export interface SchemaResponse {
+  tables: TableSchema[];
+  table_count: number;
+}
+
+export interface CacheStats {
+  l1_hits: number;
+  l1_misses: number;
+  l2_hits: number;
+  l2_misses: number;
+  l1_hit_rate: number;
+  l2_hit_rate: number;
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,17 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          50: '#eff6ff',
+          500: '#3b82f6',
+          600: '#2563eb',
+          700: '#1d4ed8',
+        },
+      },
+    },
+  },
+  plugins: [],
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## What
Frontend application skeleton with Vite, React 18, TypeScript, and Tailwind CSS.

## Why
The frontend needs a foundation before building UI components. Vite provides 10x faster dev server vs CRA. TypeScript catches errors at compile time. Tailwind eliminates CSS naming fights with utility classes. This stack is what Stripe, Linear, and Vercel use today.

## How
- **Vite 5** with React plugin, dev server on :3000, /api proxy to backend
- **TypeScript 5.6** strict mode (noUnusedLocals, noUnusedParameters)
- **Tailwind 3.4** with custom brand color palette
- **Axios** API client with full TypeScript types matching backend Pydantic models
- **Layout** component with branded header
- All API endpoints typed: query, history, schema, cache

## Verification
- [x] `npm run build` succeeds (144KB JS / 46KB gzip)
- [x] TypeScript compiles with zero errors
- [ ] CI build-frontend job passes

Closes #14