### PR TITLE
feat(frontend): query input component with API integration

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,10 @@
 import { Layout } from './components/Layout';
+import { QueryPage } from './pages/QueryPage';
 
 function App() {
   return (
     <Layout>
-      <div className="bg-white rounded-lg shadow-sm border border-slate-200 p-8">
-        <h2 className="text-2xl font-semibold text-slate-900">Welcome to QueryMate AI</h2>
-        <p className="mt-2 text-slate-600">
-          Frontend setup complete. Query interface coming in the next PR.
-        </p>
-      </div>
+      <QueryPage />
     </Layout>
   );
 }

--- a/frontend/src/components/QueryInput.tsx
+++ b/frontend/src/components/QueryInput.tsx
@@ -1,0 +1,97 @@
+import { useState, type FormEvent, type KeyboardEvent } from 'react';
+
+const EXAMPLE_QUERIES = [
+  'How many customers are in California?',
+  'What are the top 5 best-selling products?',
+  'Show me orders placed last month',
+  'What is the average order value by category?',
+];
+
+interface QueryInputProps {
+  onSubmit: (question: string) => void;
+  loading: boolean;
+}
+
+export function QueryInput({ onSubmit, loading }: QueryInputProps) {
+  const [question, setQuestion] = useState('');
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (!question.trim() || loading) return;
+    onSubmit(question.trim());
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      handleSubmit(e as unknown as FormEvent);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <div className="relative">
+        <textarea
+          value={question}
+          onChange={(e) => setQuestion(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Ask anything about your data..."
+          rows={3}
+          className="w-full px-4 py-3 border border-slate-300 rounded-lg shadow-sm
+                     focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent
+                     resize-none text-slate-900 placeholder-slate-400"
+          disabled={loading}
+        />
+        <div className="absolute bottom-3 right-3 text-xs text-slate-400">
+          ⌘+Enter to submit
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2 items-center">
+        <button
+          type="submit"
+          disabled={loading || !question.trim()}
+          className="px-5 py-2 bg-brand-600 text-white font-medium rounded-md
+                     hover:bg-brand-700 disabled:bg-slate-300 disabled:cursor-not-allowed
+                     transition-colors flex items-center gap-2"
+        >
+          {loading ? (
+            <>
+              <Spinner /> Generating SQL...
+            </>
+          ) : (
+            'Run Query'
+          )}
+        </button>
+
+        <span className="text-sm text-slate-500 ml-2">Try:</span>
+        {EXAMPLE_QUERIES.slice(0, 3).map((q) => (
+          <button
+            key={q}
+            type="button"
+            onClick={() => setQuestion(q)}
+            disabled={loading}
+            className="text-xs px-2.5 py-1 bg-slate-100 text-slate-700 rounded
+                       hover:bg-slate-200 transition-colors disabled:opacity-50"
+          >
+            {q}
+          </button>
+        ))}
+      </div>
+    </form>
+  );
+}
+
+function Spinner() {
+  return (
+    <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
+      <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" className="opacity-25" />
+      <path
+        d="M4 12a8 8 0 018-8"
+        stroke="currentColor"
+        strokeWidth="3"
+        strokeLinecap="round"
+        className="opacity-75"
+      />
+    </svg>
+  );
+}

--- a/frontend/src/components/SchemaExplorer.tsx
+++ b/frontend/src/components/SchemaExplorer.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react';
+import { useSchema } from '../hooks/useSchema';
+import type { TableSchema } from '../types';
+
+export function SchemaExplorer() {
+  const { schema, loading, error } = useSchema();
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const toggle = (table: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(table)) next.delete(table);
+      else next.add(table);
+      return next;
+    });
+  };
+
+  if (loading) {
+    return (
+      <div className="bg-white border border-slate-200 rounded-lg p-4">
+        <div className="text-sm text-slate-500">Loading schema...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-white border border-slate-200 rounded-lg p-4">
+        <div className="text-sm text-red-600">Failed to load schema: {error}</div>
+      </div>
+    );
+  }
+
+  if (!schema) return null;
+
+  return (
+    <div className="bg-white border border-slate-200 rounded-lg overflow-hidden">
+      <div className="px-4 py-3 border-b border-slate-200 bg-slate-50">
+        <h3 className="font-semibold text-slate-900">Database Schema</h3>
+        <p className="text-xs text-slate-500 mt-0.5">
+          {schema.table_count} tables · click to explore
+        </p>
+      </div>
+      <div className="divide-y divide-slate-100 max-h-[500px] overflow-y-auto">
+        {schema.tables.map((table) => (
+          <TableRow
+            key={table.name}
+            table={table}
+            isExpanded={expanded.has(table.name)}
+            onToggle={() => toggle(table.name)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface TableRowProps {
+  table: TableSchema;
+  isExpanded: boolean;
+  onToggle: () => void;
+}
+
+function TableRow({ table, isExpanded, onToggle }: TableRowProps) {
+  return (
+    <div>
+      <button
+        onClick={onToggle}
+        className="w-full px-4 py-2.5 flex items-center justify-between
+                   hover:bg-slate-50 transition-colors text-left"
+      >
+        <div className="flex items-center gap-2">
+          <span className="text-slate-400 text-xs">{isExpanded ? '▼' : '▶'}</span>
+          <span className="font-mono text-sm text-slate-900">{table.name}</span>
+          {table.row_count !== null && (
+            <span className="text-xs text-slate-500">~{table.row_count} rows</span>
+          )}
+        </div>
+        <span className="text-xs text-slate-400">{table.columns.length} cols</span>
+      </button>
+
+      {isExpanded && (
+        <div className="px-4 pb-3 bg-slate-50/50">
+          <table className="w-full text-xs">
+            <tbody className="divide-y divide-slate-100">
+              {table.columns.map((col) => (
+                <tr key={col.name}>
+                  <td className="py-1.5 pr-2 font-mono text-slate-900">
+                    {col.is_primary_key && <span title="Primary Key">🔑 </span>}
+                    {col.name}
+                  </td>
+                  <td className="py-1.5 pr-2 text-slate-500">{col.data_type}</td>
+                  <td className="py-1.5 text-slate-400">
+                    {col.foreign_key && <span>→ {col.foreign_key}</span>}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/SqlDisplay.tsx
+++ b/frontend/src/components/SqlDisplay.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+
+interface SqlDisplayProps {
+  sql: string;
+  cached?: boolean;
+  cacheLevel?: string | null;
+  executionTimeMs?: number;
+}
+
+export function SqlDisplay({ sql, cached, cacheLevel, executionTimeMs }: SqlDisplayProps) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    await navigator.clipboard.writeText(sql);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <div className="bg-slate-900 rounded-lg overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-2 bg-slate-800 border-b border-slate-700">
+        <div className="flex items-center gap-3">
+          <span className="text-xs font-medium text-slate-300">Generated SQL</span>
+          {cached && (
+            <span
+              className="text-xs px-2 py-0.5 bg-emerald-900/50 text-emerald-300 rounded
+                         border border-emerald-800"
+              title={`Cache hit at level ${cacheLevel}`}
+            >
+              ● cached ({cacheLevel})
+            </span>
+          )}
+          {executionTimeMs !== undefined && (
+            <span className="text-xs text-slate-400">{executionTimeMs.toFixed(1)}ms</span>
+          )}
+        </div>
+        <button
+          onClick={copy}
+          className="text-xs text-slate-300 hover:text-white transition-colors"
+        >
+          {copied ? 'Copied!' : 'Copy'}
+        </button>
+      </div>
+      <pre className="p-4 text-sm text-slate-100 font-mono overflow-x-auto whitespace-pre-wrap">
+        {sql}
+      </pre>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useQuery.ts
+++ b/frontend/src/hooks/useQuery.ts
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import axios from 'axios';
+import { api } from '../api/client';
+import type { QueryResponse } from '../types';
+
+interface UseQueryReturn {
+  loading: boolean;
+  error: string | null;
+  violations: string[] | null;
+  response: QueryResponse | null;
+  submit: (question: string) => Promise<void>;
+  reset: () => void;
+}
+
+export function useQuery(): UseQueryReturn {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [violations, setViolations] = useState<string[] | null>(null);
+  const [response, setResponse] = useState<QueryResponse | null>(null);
+
+  const submit = async (question: string) => {
+    setLoading(true);
+    setError(null);
+    setViolations(null);
+    setResponse(null);
+
+    try {
+      const data = await api.query({ question });
+      setResponse(data);
+    } catch (err) {
+      if (axios.isAxiosError(err) && err.response) {
+        const detail = err.response.data?.detail;
+        if (typeof detail === 'object' && detail.violations) {
+          setError(detail.message || 'Query blocked');
+          setViolations(detail.violations);
+        } else if (typeof detail === 'object' && detail.message) {
+          setError(detail.message);
+        } else {
+          setError(typeof detail === 'string' ? detail : 'Request failed');
+        }
+      } else {
+        setError(err instanceof Error ? err.message : 'Unknown error');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const reset = () => {
+    setError(null);
+    setViolations(null);
+    setResponse(null);
+  };
+
+  return { loading, error, violations, response, submit, reset };
+}

--- a/frontend/src/hooks/useSchema.ts
+++ b/frontend/src/hooks/useSchema.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import { api } from '../api/client';
+import type { SchemaResponse } from '../types';
+
+export function useSchema() {
+  const [schema, setSchema] = useState<SchemaResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    api
+      .getSchema()
+      .then((data) => {
+        if (mounted) setSchema(data);
+      })
+      .catch((err) => {
+        if (mounted) setError(err.message ?? 'Failed to load schema');
+      })
+      .finally(() => {
+        if (mounted) setLoading(false);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return { schema, loading, error };
+}

--- a/frontend/src/pages/QueryPage.tsx
+++ b/frontend/src/pages/QueryPage.tsx
@@ -1,0 +1,60 @@
+import { QueryInput } from '../components/QueryInput';
+import { SchemaExplorer } from '../components/SchemaExplorer';
+import { SqlDisplay } from '../components/SqlDisplay';
+import { useQuery } from '../hooks/useQuery';
+
+export function QueryPage() {
+  const { loading, error, violations, response, submit } = useQuery();
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-6">
+      {/* Main column */}
+      <div className="space-y-4">
+        <div className="bg-white rounded-lg shadow-sm border border-slate-200 p-5">
+          <QueryInput onSubmit={submit} loading={loading} />
+        </div>
+
+        {error && (
+          <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+            <div className="font-medium text-red-900">{error}</div>
+            {violations && violations.length > 0 && (
+              <ul className="mt-2 text-sm text-red-800 list-disc list-inside space-y-0.5">
+                {violations.map((v, i) => (
+                  <li key={i}>{v}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+
+        {response && (
+          <div className="space-y-4">
+            <SqlDisplay
+              sql={response.sql}
+              cached={response.cached}
+              cacheLevel={response.cache_level}
+              executionTimeMs={response.execution_time_ms}
+            />
+            {response.result && (
+              <div className="bg-white border border-slate-200 rounded-lg p-4">
+                <div className="text-sm text-slate-600">
+                  Got <span className="font-semibold">{response.result.row_count}</span> rows
+                  in {response.result.execution_time_ms.toFixed(1)}ms
+                  {response.result.truncated && ' (truncated)'}
+                </div>
+                <div className="mt-2 text-xs text-slate-400">
+                  Results table & charts coming in the next PR.
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Sidebar */}
+      <div>
+        <SchemaExplorer />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What
Main query interface — textarea input, schema sidebar, SQL display, and error handling.

## Why
This is where users actually interact with QueryMate. Custom hooks (`useQuery`, `useSchema`) keep components focused on rendering. The schema sidebar helps users formulate better questions by showing available tables and columns.

## How
- **`useQuery` hook** — Wraps API call with state (loading/error/violations/response), parses validator violations from axios errors
- **`useSchema` hook** — Loads schema once on mount with cleanup
- **`QueryInput`** — Textarea with Cmd+Enter shortcut, example query chips, animated spinner
- **`SchemaExplorer`** — Collapsible table list, expand to see columns/types/PKs/FKs
- **`SqlDisplay`** — SQL viewer with cache hit badge (green if cached), execution time, copy button
- **`QueryPage`** — 2-column layout: main query area + schema sidebar

## Verification
- [x] `npm run build` succeeds (194KB JS / 65KB gzip)
- [x] TypeScript strict mode passes
- [ ] Manual test once backend is running

Closes #15