### PR TITLE
feat(frontend): results table, chart visualization, query history

### DIFF
--- a/frontend/src/components/ChartView.tsx
+++ b/frontend/src/components/ChartView.tsx
@@ -1,0 +1,82 @@
+import {
+  BarChart,
+  Bar,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import type { QueryResult } from '../types';
+
+interface ChartViewProps {
+  result: QueryResult;
+}
+
+type ChartType = 'bar' | 'line' | 'none';
+
+function detectChartType(result: QueryResult): ChartType {
+  if (result.columns.length !== 2 || result.row_count === 0 || result.row_count > 100) {
+    return 'none';
+  }
+
+  const sample = result.rows[0];
+  const [first, second] = sample;
+
+  // Numeric Y axis required
+  if (typeof second !== 'number') return 'none';
+
+  // Date-like X axis → line chart
+  if (typeof first === 'string' && /^\d{4}-\d{2}/.test(first)) return 'line';
+
+  // Categorical X axis → bar chart
+  if (typeof first === 'string' || typeof first === 'number') return 'bar';
+
+  return 'none';
+}
+
+export function ChartView({ result }: ChartViewProps) {
+  const chartType = detectChartType(result);
+
+  if (chartType === 'none') return null;
+
+  const data = result.rows.map((row) => ({
+    [result.columns[0]]: row[0],
+    [result.columns[1]]: row[1],
+  }));
+
+  return (
+    <div className="bg-white border border-slate-200 rounded-lg p-4">
+      <div className="text-xs font-medium text-slate-500 mb-3 uppercase tracking-wide">
+        {chartType === 'bar' ? 'Bar Chart' : 'Line Chart'} · auto-detected
+      </div>
+      <ResponsiveContainer width="100%" height={300}>
+        {chartType === 'bar' ? (
+          <BarChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+            <XAxis dataKey={result.columns[0]} tick={{ fontSize: 12 }} />
+            <YAxis tick={{ fontSize: 12 }} />
+            <Tooltip />
+            <Bar dataKey={result.columns[1]} fill="#3b82f6" radius={[4, 4, 0, 0]} />
+          </BarChart>
+        ) : (
+          <LineChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+            <XAxis dataKey={result.columns[0]} tick={{ fontSize: 12 }} />
+            <YAxis tick={{ fontSize: 12 }} />
+            <Tooltip />
+            <Line
+              type="monotone"
+              dataKey={result.columns[1]}
+              stroke="#3b82f6"
+              strokeWidth={2}
+              dot={{ r: 4 }}
+            />
+          </LineChart>
+        )}
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/components/QueryHistory.tsx
+++ b/frontend/src/components/QueryHistory.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react';
+import { api } from '../api/client';
+import type { HistoryItem } from '../types';
+
+interface QueryHistoryProps {
+  onSelect: (question: string) => void;
+  refreshKey: number;
+}
+
+export function QueryHistory({ onSelect, refreshKey }: QueryHistoryProps) {
+  const [items, setItems] = useState<HistoryItem[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    setLoading(true);
+    api
+      .getHistory(1, 10)
+      .then((data) => {
+        if (mounted) setItems(data.items);
+      })
+      .catch(() => {
+        if (mounted) setItems([]);
+      })
+      .finally(() => {
+        if (mounted) setLoading(false);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [refreshKey]);
+
+  if (!loading && items.length === 0) {
+    return (
+      <div className="bg-white border border-slate-200 rounded-lg p-4">
+        <div className="text-sm text-slate-500">No queries yet. Run one to get started.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white border border-slate-200 rounded-lg overflow-hidden">
+      <div className="px-4 py-3 border-b border-slate-200 bg-slate-50">
+        <h3 className="font-semibold text-slate-900">Recent Queries</h3>
+        <p className="text-xs text-slate-500 mt-0.5">click to re-run</p>
+      </div>
+      <div className="divide-y divide-slate-100 max-h-[300px] overflow-y-auto">
+        {items.map((item) => (
+          <button
+            key={item.id}
+            onClick={() => onSelect(item.natural_language)}
+            className="w-full px-4 py-2.5 text-left hover:bg-slate-50 transition-colors"
+          >
+            <div className="flex items-center gap-2">
+              <span
+                className={`w-2 h-2 rounded-full flex-shrink-0 ${
+                  item.was_cached ? 'bg-emerald-500' : 'bg-slate-300'
+                }`}
+                title={item.was_cached ? `Cached (${item.cache_level})` : 'Fresh query'}
+              />
+              <span className="text-sm text-slate-900 truncate">{item.natural_language}</span>
+            </div>
+            <div className="ml-4 mt-0.5 text-xs text-slate-500">
+              {item.error ? (
+                <span className="text-red-600">error</span>
+              ) : (
+                <>
+                  {item.row_count} rows · {item.execution_time_ms?.toFixed(0)}ms
+                </>
+              )}
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/QueryInput.tsx
+++ b/frontend/src/components/QueryInput.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent, type KeyboardEvent } from 'react';
+import { useEffect, useState, type FormEvent, type KeyboardEvent } from 'react';
 
 const EXAMPLE_QUERIES = [
   'How many customers are in California?',
@@ -10,10 +10,15 @@ const EXAMPLE_QUERIES = [
 interface QueryInputProps {
   onSubmit: (question: string) => void;
   loading: boolean;
+  initialValue?: string | null;
 }
 
-export function QueryInput({ onSubmit, loading }: QueryInputProps) {
+export function QueryInput({ onSubmit, loading, initialValue }: QueryInputProps) {
   const [question, setQuestion] = useState('');
+
+  useEffect(() => {
+    if (initialValue) setQuestion(initialValue);
+  }, [initialValue]);
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();

--- a/frontend/src/components/ResultsTable.tsx
+++ b/frontend/src/components/ResultsTable.tsx
@@ -1,0 +1,122 @@
+import { useMemo, useState } from 'react';
+import type { QueryResult } from '../types';
+
+const PAGE_SIZE = 25;
+
+interface ResultsTableProps {
+  result: QueryResult;
+}
+
+type SortDirection = 'asc' | 'desc';
+
+export function ResultsTable({ result }: ResultsTableProps) {
+  const [page, setPage] = useState(1);
+  const [sortCol, setSortCol] = useState<number | null>(null);
+  const [sortDir, setSortDir] = useState<SortDirection>('asc');
+
+  const sortedRows = useMemo(() => {
+    if (sortCol === null) return result.rows;
+    const sorted = [...result.rows].sort((a, b) => {
+      const av = a[sortCol];
+      const bv = b[sortCol];
+      if (av === bv) return 0;
+      if (av === null) return 1;
+      if (bv === null) return -1;
+      const cmp = av < bv ? -1 : 1;
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+    return sorted;
+  }, [result.rows, sortCol, sortDir]);
+
+  const pagedRows = useMemo(
+    () => sortedRows.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE),
+    [sortedRows, page],
+  );
+
+  const totalPages = Math.max(1, Math.ceil(result.rows.length / PAGE_SIZE));
+
+  const handleSort = (colIndex: number) => {
+    if (sortCol === colIndex) {
+      setSortDir(sortDir === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortCol(colIndex);
+      setSortDir('asc');
+    }
+  };
+
+  if (result.row_count === 0) {
+    return (
+      <div className="bg-white border border-slate-200 rounded-lg p-6 text-center">
+        <div className="text-slate-500">No rows returned.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white border border-slate-200 rounded-lg overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-50 border-b border-slate-200">
+            <tr>
+              {result.columns.map((col, idx) => (
+                <th
+                  key={col}
+                  onClick={() => handleSort(idx)}
+                  className="px-4 py-2.5 text-left font-semibold text-slate-700
+                             cursor-pointer hover:bg-slate-100 select-none"
+                >
+                  <div className="flex items-center gap-1">
+                    {col}
+                    <span className="text-slate-400 text-xs">
+                      {sortCol === idx ? (sortDir === 'asc' ? '▲' : '▼') : '⇅'}
+                    </span>
+                  </div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {pagedRows.map((row, rowIdx) => (
+              <tr key={rowIdx} className="hover:bg-slate-50">
+                {row.map((cell, cellIdx) => (
+                  <td key={cellIdx} className="px-4 py-2 text-slate-900 font-mono text-xs">
+                    {cell === null ? <span className="text-slate-400 italic">null</span> : String(cell)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="px-4 py-2.5 border-t border-slate-200 bg-slate-50 flex items-center justify-between text-xs text-slate-600">
+        <div>
+          Showing {(page - 1) * PAGE_SIZE + 1}–{Math.min(page * PAGE_SIZE, result.row_count)} of{' '}
+          {result.row_count}
+          {result.truncated && <span className="ml-2 text-amber-600">(truncated to first 1000)</span>}
+        </div>
+        {totalPages > 1 && (
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={page === 1}
+              className="px-2 py-1 border border-slate-300 rounded hover:bg-white disabled:opacity-40"
+            >
+              ←
+            </button>
+            <span>
+              Page {page} / {totalPages}
+            </span>
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              disabled={page === totalPages}
+              className="px-2 py-1 border border-slate-300 rounded hover:bg-white disabled:opacity-40"
+            >
+              →
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/QueryPage.tsx
+++ b/frontend/src/pages/QueryPage.tsx
@@ -1,17 +1,36 @@
+import { useState } from 'react';
+import { ChartView } from '../components/ChartView';
+import { QueryHistory } from '../components/QueryHistory';
 import { QueryInput } from '../components/QueryInput';
+import { ResultsTable } from '../components/ResultsTable';
 import { SchemaExplorer } from '../components/SchemaExplorer';
 import { SqlDisplay } from '../components/SqlDisplay';
 import { useQuery } from '../hooks/useQuery';
 
 export function QueryPage() {
   const { loading, error, violations, response, submit } = useQuery();
+  const [historyKey, setHistoryKey] = useState(0);
+  const [pendingQuestion, setPendingQuestion] = useState<string | null>(null);
+
+  const handleSubmit = async (question: string) => {
+    await submit(question);
+    setHistoryKey((k) => k + 1);
+  };
+
+  const handleHistorySelect = (question: string) => {
+    setPendingQuestion(question);
+    handleSubmit(question);
+  };
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-6">
-      {/* Main column */}
       <div className="space-y-4">
         <div className="bg-white rounded-lg shadow-sm border border-slate-200 p-5">
-          <QueryInput onSubmit={submit} loading={loading} />
+          <QueryInput
+            onSubmit={handleSubmit}
+            loading={loading}
+            initialValue={pendingQuestion}
+          />
         </div>
 
         {error && (
@@ -36,24 +55,18 @@ export function QueryPage() {
               executionTimeMs={response.execution_time_ms}
             />
             {response.result && (
-              <div className="bg-white border border-slate-200 rounded-lg p-4">
-                <div className="text-sm text-slate-600">
-                  Got <span className="font-semibold">{response.result.row_count}</span> rows
-                  in {response.result.execution_time_ms.toFixed(1)}ms
-                  {response.result.truncated && ' (truncated)'}
-                </div>
-                <div className="mt-2 text-xs text-slate-400">
-                  Results table & charts coming in the next PR.
-                </div>
-              </div>
+              <>
+                <ChartView result={response.result} />
+                <ResultsTable result={response.result} />
+              </>
             )}
           </div>
         )}
       </div>
 
-      {/* Sidebar */}
-      <div>
+      <div className="space-y-4">
         <SchemaExplorer />
+        <QueryHistory onSelect={handleHistorySelect} refreshKey={historyKey} />
       </div>
     </div>
   );


### PR DESCRIPTION
## What
Three components that complete the frontend UX: data table, auto-detected charts, and query history.

## Why
Users need to see results in the right format. Numeric trends should be charts, dimensional data should be tables. Asking the user "table or chart?" is friction — auto-detection eliminates it. History lets users re-run common queries with one click.

## How

### ResultsTable
- Client-side sorting (click column header to toggle asc/desc)
- Pagination (25 rows/page) with prev/next controls
- Null values styled distinctly (italic gray)
- Truncation warning when result hit `max_result_rows`

### ChartView (Auto-detection)
| Data Shape | Chart Type |
|------------|-----------|
| 2 cols, string + number | Bar chart |
| 2 cols, date-like + number | Line chart |
| Anything else | No chart (table only) |

Date detection via regex `/^\d{4}-\d{2}/` (ISO date prefix).

### QueryHistory
- Last 10 queries with cache hit indicator (🟢 cached, ⚪ fresh)
- Click to re-run via `initialValue` prop on QueryInput
- Refreshes after each new query via `refreshKey` counter

## Verification
- [x] `npm run build` succeeds
- [x] TypeScript strict mode passes
- [x] Auto-detection logic matches design

Closes #16